### PR TITLE
optionally derive traits on generated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fed"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Scott Steele <scottlsteele@gmail.com>"]
 
 homepage = "https://github.com/scooter-dangle/fed-rs"
@@ -11,3 +11,8 @@ documentation = "https://docs.rs/fed/0.2.2/fed"
 license = "Apache-2.0"
 
 [dependencies]
+
+[dev_dependencies]
+serde = "1.0.11"
+serde_derive = "1.0.11"
+bincode = "0.8.0"

--- a/examples/derive_serde.rs
+++ b/examples/derive_serde.rs
@@ -1,0 +1,28 @@
+#[macro_use]
+extern crate fed as fed_;
+
+#[macro_use]
+extern crate serde_derive;
+extern crate bincode;
+
+use bincode::{serialize, deserialize, Infinite};
+
+init_fed!(@deriving:[Serialize, Deserialize]);
+use fed::*;
+
+fed!(
+    usize,
+    bool,
+    Option<String>,
+    char,
+);
+
+fn main() {
+    let a: Fed4<_,_,_,_> = 42.into();
+
+    let encoded: Vec<u8> = serialize(&a, Infinite).unwrap();
+
+    let decoded: Fed4<_,_,_,_> = deserialize(&encoded[..]).unwrap();
+
+    assert_eq!(a, decoded);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@
 
 #[macro_export]
 macro_rules! basic_fed {
-    ($typename:ident, $(($letter:ident, $f_letter:ident) => [$enum_var:ident; $arg_name:ident]),*,) => {
-        #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+    ($typename:ident, @deriving:[$($derive_trait:ident),*], $(($letter:ident, $f_letter:ident) => [$enum_var:ident; $arg_name:ident]),*,) => {
+        #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, $($derive_trait),*)]
         pub enum $typename< $($letter),* > {
             $(
             $enum_var($letter)
@@ -118,7 +118,8 @@ macro_rules! basic_fed {
 /// types.
 #[macro_export]
 macro_rules! init_fed {
-    () => {
+    () => { init_fed!(@deriving:[]); };
+    (@deriving:[$($derive_trait:ident),*]) => {
         #[allow(dead_code)]
         pub mod fed {
             pub trait Fed: Sized {
@@ -225,12 +226,14 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed2,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
             }
 
             basic_fed!{
                 Fed3,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],
@@ -238,6 +241,7 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed4,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],
@@ -246,6 +250,7 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed5,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],
@@ -255,6 +260,7 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed6,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],
@@ -265,6 +271,7 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed7,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],
@@ -276,6 +283,7 @@ macro_rules! init_fed {
 
             basic_fed!{
                 Fed8,
+                @deriving:[$($derive_trait),*],
                 (A, FA) => [T1; f_1],
                 (B, FB) => [T2; f_2],
                 (C, FC) => [T3; f_3],


### PR DESCRIPTION
This change creates a second pattern of the `init_fed!` macro which
accepts a list of traits to be derived in the generated types.

Provide an example of deriving Serialize and Deserialize from serde.